### PR TITLE
feat: add traits data to track and screen events

### DIFF
--- a/IOSApp/AppDelegate.swift
+++ b/IOSApp/AppDelegate.swift
@@ -20,6 +20,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Journify.debugLogsEnabled = true
         Journify.setup(with: configuration)
+        let traits: [String: Any] = ["data1": "data_1",
+                      "data2": 12]
+
+        Journify.shared().identify(userId: "testId", traits: traits)
 
         Journify.shared().track(name: "New Event", properties: ["Name": "Mohamed"], externalId: ["testKey": "test"])
         Journify.shared().screen(title: "New Screen", properties: ["title": "Growth as a service", "url": "https://journify.io", "path": "/"])

--- a/Sources/Journify/Plugins.swift
+++ b/Sources/Journify/Plugins.swift
@@ -161,3 +161,23 @@ extension Journify {
         return timeline.find(key: key)
     }
 }
+
+// MARK: - Adding Traits Plugin
+
+class InjectTraitsPlugin: Plugin {
+    var analytics: Journify?
+    var type: PluginType = .enrichment
+    
+    public func execute<T: RawEvent>(event: T?) -> T? {
+        var event = event
+        guard event?.type != "identify" else { return event }
+        do{
+            let traits: JSON = try JSON(analytics?.traits() ?? [:])
+            event?.traits = traits
+        } catch let error {
+            print("Failed to creat json: \(error.localizedDescription)")
+            return event
+        }
+        return event
+    }
+}

--- a/Sources/Journify/Startup.swift
+++ b/Sources/Journify/Startup.swift
@@ -12,7 +12,7 @@ extension Journify: Subscriber {
     internal func platformStartup() {
         add(plugin: JournifyLog())
         add(plugin: StartupQueue())
-        
+        add(plugin: InjectTraitsPlugin())
         // add journify destination plugin unless
         // asked not to via configuration.
         if configuration.values.autoAddSegmentDestination {

--- a/Sources/Journify/Types.swift
+++ b/Sources/Journify/Types.swift
@@ -19,6 +19,7 @@ public protocol RawEvent: Codable {
     var context: JSON? { get set }
     var integrations: JSON? { get set }
     var metrics: [JSON]? { get set }
+    var traits: JSON? { get set }
 }
 
 public struct TrackEvent: RawEvent {
@@ -30,7 +31,8 @@ public struct TrackEvent: RawEvent {
     public var context: JSON? = nil
     public var integrations: JSON? = nil
     public var metrics: [JSON]? = nil
-    
+    public var traits: JSON? = nil
+
     public var event: String
     public var properties: JSON?
     public var externalId: JSON?
@@ -56,9 +58,7 @@ public struct IdentifyEvent: RawEvent {
     public var context: JSON? = nil
     public var integrations: JSON? = nil
     public var metrics: [JSON]? = nil
-    
-    public var traits: JSON?
-    
+    public var traits: JSON? = nil
     
     public init(userId: String? = nil, traits: JSON? = nil) {
         self.userId = userId
@@ -80,7 +80,8 @@ public struct ScreenEvent: RawEvent {
     public var context: JSON? = nil
     public var integrations: JSON? = nil
     public var metrics: [JSON]? = nil
-    
+    public var traits: JSON? = nil
+
     public var name: String?
     public var category: String?
     public var properties: JSON?

--- a/Tests/Journify-Tests/Journify_Tests.swift
+++ b/Tests/Journify-Tests/Journify_Tests.swift
@@ -160,6 +160,42 @@ final class Journify_Tests: XCTestCase {
         XCTAssertTrue(props?["email"] as? String == "ben@med.com")
     }
     
+    func testTraitsExistenceInTrackEvents() {
+        Journify.setup(with: Configuration(writeKey: "test"))
+        let outputReader = OutputReaderPlugin()
+        Journify.shared().add(plugin: outputReader)
+        
+        waitUntilStarted(analytics: Journify.shared())
+        
+        Journify.shared().identify(userId: "BenMed", traits: MyTraits(email: "ben@med.com"))
+        Journify.shared().track(name: "test track")
+        
+        let trackEvent: TrackEvent? = outputReader.lastEvent as? TrackEvent
+        let traits = trackEvent?.traits?.dictionaryValue
+
+        XCTAssertTrue(trackEvent?.event == "test track")
+        XCTAssertTrue(trackEvent?.type == "track")
+        XCTAssertTrue(traits?["email"] as? String == "ben@med.com")
+    }
+    
+    func testTraitsExistenceInScreenEvents() {
+        Journify.setup(with: Configuration(writeKey: "test"))
+        let outputReader = OutputReaderPlugin()
+        Journify.shared().add(plugin: outputReader)
+        
+        waitUntilStarted(analytics: Journify.shared())
+        
+        Journify.shared().identify(userId: "BenMed", traits: MyTraits(email: "ben@med.com"))
+        Journify.shared().screen(title: "screen1", category: "category1")
+
+        let screenEvent: ScreenEvent? = outputReader.lastEvent as? ScreenEvent
+        let traits = screenEvent?.traits?.dictionaryValue
+
+        XCTAssertTrue(screenEvent?.name == "screen1")
+        XCTAssertTrue(screenEvent?.type == "page")
+        XCTAssertTrue(traits?["email"] as? String == "ben@med.com")
+    }
+    
     func testReset() {
         Journify.setup(with: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()


### PR DESCRIPTION
We included traits in the Track and Screen event types within the Context object whenever they were available